### PR TITLE
Improved Setup Instructions and Environment Variable Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ FastAPI Single Sign On example with various providers and minimal home page that
 * Activate the virtual environment: `source venv/bin/activate`
 * Install dependencies: `python3.11 -m pip install -r requirements.txt`
 
+## Setup and Configuration
+
+* Create a `.env` file in the project root directory.
+* Add the following environment variable key-value pairs to the `.env` file:<br>
+    * `SECRET_KEY=your_secret_key_value`<br>
+    * `SESSION_COOKIE_NAME=your_cookie_name_value`
+
 ## Use the project
 * While in activated virtual environment, run with: `python3.11 main.py`
 

--- a/authentication.py
+++ b/authentication.py
@@ -14,11 +14,9 @@ directory_path = Path(__file__).parent
 env_file_path = directory_path / '.env'
 
 load_dotenv()
-SECRET_KEY = os.getenv("SECRET_KEY")
-SESSION_COOKIE_NAME = os.getenv("SESSION_COOKIE_NAME")
+SECRET_KEY = os.getenv("SECRET_KEY", "default_secret_key")
+SESSION_COOKIE_NAME = os.getenv("SESSION_COOKIE_NAME", "default_session_cookie_name")
 
-if SESSION_COOKIE_NAME is None:
-    SESSION_COOKIE_NAME = "default_session_cookie_name"
 
 COOKIE = APIKeyCookie(name=SESSION_COOKIE_NAME, auto_error=False)
 

--- a/authentication.py
+++ b/authentication.py
@@ -16,8 +16,11 @@ env_file_path = directory_path / '.env'
 load_dotenv()
 SECRET_KEY = os.getenv("SECRET_KEY")
 SESSION_COOKIE_NAME = os.getenv("SESSION_COOKIE_NAME")
-COOKIE = APIKeyCookie(name=SESSION_COOKIE_NAME, auto_error=False)
 
+if SESSION_COOKIE_NAME is None:
+    SESSION_COOKIE_NAME = "default_session_cookie_name"
+
+COOKIE = APIKeyCookie(name=SESSION_COOKIE_NAME, auto_error=False)
 
 class BearAuthException(Exception):
     pass


### PR DESCRIPTION
Changes Made:

-    Added a new section to the README.md file titled "Setup and Configuration" that guides users on creating a .env file and 
      handling environment variables.
-    Provided clear instructions on how to set environment variable key-value pairs for SECRET_KEY and SESSION_COOKIE_NAME.
-    Handled the case where SESSION_COOKIE_NAME might be None by providing a default value.

I was facing the following issue while trying to follow the instructions on the readme file, therefore I've tried to see if I can help.

```    self.model: APIKey = APIKey(
                         ^^^^^^^
  File "pydantic\main.py", line 341, in pydantic.main.BaseModel.init
pydantic.error_wrappers.ValidationError: 1 validation error for APIKey
name
  none is not an allowed value (type=type_error.none.not_allowed)
```
Best regards,
FloareDor